### PR TITLE
Add Flac support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,9 @@ site/_site/*
 .sass-cache
 
 # Remove our sounds for the moment
-site/sounds/*
-site/sounds_familiarisation/*
-site/sounds_training/*
+site/sounds/*/*.wav
+site/sounds_familiarisation/*.wav
+site/sounds_training/*/*.wav
 
 # Ignore installed virtual envs
 /venvs/py3/*

--- a/convert_to_flac.sh
+++ b/convert_to_flac.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+usage() {
+    echo ""
+    echo "Usage: $0 [--help]"
+    echo ""
+    echo "Options:"
+    echo "  --help      show this help message"
+    exit 0
+}
+
+issubstring() {
+    echo "$2" | grep -F "$1"
+    return $?
+}
+
+wav2flac() {
+    # Remove unneded wav files
+    for FILE in $(find $1/Artefacts.wav -type f 2>/dev/null); do
+        rm "$FILE"
+    done
+    for FILE in $(find $1/Distortion.wav -type f 2>/dev/null); do
+        rm "$FILE"
+    done
+    for FILE in $(find $1/*.wav -type f); do
+        # Skip unnneded files
+        issubstring "Artefacts" "$FILE" && continue
+        issubstring "Distortion" "$FILE" && continue
+        # Otherwise convert to 16bit wav and flac
+        sox "$FILE" -b 16 "$FILE.wav" gain -3
+        flac --silent "$FILE.wav" > /dev/null
+        mv "$FILE.flac" "${FILE%.wav}.flac"
+        rm "$FILE.wav"
+    done
+}
+
+# Input parameter
+[ "$#" -gt 0 ] && usage  # no arg required
+
+# Exit if any command fails
+set -e
+
+wav2flac 'site/sounds/*'
+wav2flac 'site/sounds_training/*'
+wav2flac 'site/sounds_familiarisation'

--- a/switch_between_wav_or_flac.sh
+++ b/switch_between_wav_or_flac.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+usage() {
+    echo ""
+    echo "Usage: $0 --option"
+    echo ""
+    echo "Options:"
+    echo "  --flac      update listening test to use flac"
+    echo "  --wav       update listening test to use wav"
+    echo "  --help      show this help message"
+    exit 0
+}
+
+# Input parameter
+[ "$#" -eq 1 ] || usage  # exactly one parameter required
+case "$1" in
+    --flac) FORMATSTR='s/.wav/.flac/g';;
+    --wav)  FORMATSTR='s/.flac/.wav/g';;
+    *) usage;;
+esac
+
+# Exit if any command fails
+set -e
+
+# Update config files
+if $CONFIG; then
+    for FILE in "interferer.yaml" "quality.yaml" "training_interferer.yaml" "training_quality.yaml" "familiarisation.yaml"; do
+        sed -i ''$FORMATSTR'' "site/_data/$FILE"
+    done
+fi


### PR DESCRIPTION
This adds the script `convert_to_flac.sh` for converting the 32bit wav files to 16bit flac files using `sox` and `flac`. In addition, the script `switch_between_wav_or_flac.sh` allows you to switch which stimuli you would like to use in the listening test by
```bash
$ ./switch_between_wav_or_flac.sh --flac
$ ./switch_between_wav_or_flac.sh --wav
```
The *.wav files are ignored by git, the flac files aren't.