### PR TITLE
Add type of test to familiarisation page headings

### DIFF
--- a/site/_pages/familiarisation_interferer/index.md
+++ b/site/_pages/familiarisation_interferer/index.md
@@ -5,7 +5,7 @@ permalink: /familiarisation_interferer/
 next_url: /training_interferer/
 ---
 
-# Familiarisation
+# Familiarisation: Interference
 
 **Interference** describes the loudness of the instruments compared to the
 loudness of the vocals. For example, 'strong interference' indicates a strong

--- a/site/_pages/familiarisation_quality/index.md
+++ b/site/_pages/familiarisation_quality/index.md
@@ -5,7 +5,7 @@ permalink: /familiarisation_quality/
 next_url: /training_quality/
 ---
 
-# Familiarisation
+# Familiarisation: Sound quality
 
 **Sound quality** relates to the amount of artefacts or distortions
 that you can perceive.


### PR DESCRIPTION
This tries to focus more on the actual task of the current test and makes it identical to the next page were the headings are `Training: Interference` and `Training: Sound quality`